### PR TITLE
Linked list mutable csr

### DIFF
--- a/apps/cpp/test_linkedlist_csr.cpp
+++ b/apps/cpp/test_linkedlist_csr.cpp
@@ -70,7 +70,7 @@ class WCCPIE : public minigraph::AutoAppBase<GRAPH_T, CONTEXT_T> {
              minigraph::executors::TaskRunner* task_runner) override {
     LOG_INFO("PEval() - Processing gid: ", graph.gid_,
              " num_vertexes: ", graph.get_num_vertexes());
-    graph.ShowGraph(99);
+    // graph.ShowGraph(99);
     if (!graph.IsInGraph(0)) return true;
     auto vid_map = this->msg_mngr_->GetVidMap();
     auto start_time = std::chrono::system_clock::now();
@@ -89,21 +89,30 @@ class WCCPIE : public minigraph::AutoAppBase<GRAPH_T, CONTEXT_T> {
     auto graph_a = pair_graphs.first;
     auto graph_b = pair_graphs.second;
 
-    graph_a->ShowGraph(99);
-    graph_b->ShowGraph(99);
+    // graph_a->ShowGraph(99);
+    // graph_b->ShowGraph(99);
 
-    split_merge.Merge(linkedlist_mutable_csr, graph_a);
-    split_merge.Merge(linkedlist_mutable_csr, graph_b);
+    // split_merge.Merge(linkedlist_mutable_csr, graph_a);
+    // split_merge.Merge(linkedlist_mutable_csr, graph_b);
+    // auto u = linkedlist_mutable_csr->GetVertexByVid(4);
+    // u.ShowVertexInfo();
 
-    auto u = linkedlist_mutable_csr->GetVertexByVid(4);
-    u.ShowVertexInfo();
+    // auto pair_graphs_a = split_merge.Split(*graph_a);
+    // auto graph_aa = pair_graphs_a.first;
+    // auto graph_ab = pair_graphs_a.second;
+
+    auto pair_graphs_b = split_merge.Split(*graph_b);
+    auto graph_ba = pair_graphs_b.first;
+    auto graph_bb = pair_graphs_b.second;
+    graph_ba->ShowGraph(99);
+    graph_bb->ShowGraph(99);
 
     return true;
   }
 
   bool IncEval(GRAPH_T& graph,
                minigraph::executors::TaskRunner* task_runner) override {
-   return false;
+    return false;
   }
 
   bool Aggregate(void* a, void* b,

--- a/apps/cpp/test_linkedlist_csr.cpp
+++ b/apps/cpp/test_linkedlist_csr.cpp
@@ -89,11 +89,8 @@ class WCCPIE : public minigraph::AutoAppBase<GRAPH_T, CONTEXT_T> {
     auto graph_a = pair_graphs.first;
     auto graph_b = pair_graphs.second;
 
-    LOG_INFO("X");
     graph_a->ShowGraph(99);
-    LOG_INFO("X");
     graph_b->ShowGraph(99);
-    LOG_INFO("X");
 
     split_merge.Merge(linkedlist_mutable_csr, graph_a);
     split_merge.Merge(linkedlist_mutable_csr, graph_b);

--- a/apps/cpp/test_linkedlist_csr.cpp
+++ b/apps/cpp/test_linkedlist_csr.cpp
@@ -1,0 +1,144 @@
+#include "2d_pie/auto_app_base.h"
+#include "executors/task_runner.h"
+#include "graphs/graph.h"
+#include "graphs/linked_list_mutable_csr.h"
+#include "minigraph_sys.h"
+#include "portability/sys_data_structure.h"
+#include "portability/sys_types.h"
+#include "utility/bitmap.h"
+#include "utility/dynamic/split_merge.h"
+#include "utility/logging.h"
+
+template <typename GRAPH_T, typename CONTEXT_T>
+class WCCAutoMap : public minigraph::AutoMapBase<GRAPH_T, CONTEXT_T> {
+  using GID_T = typename GRAPH_T::gid_t;
+  using VID_T = typename GRAPH_T::vid_t;
+  using VDATA_T = typename GRAPH_T::vdata_t;
+  using EDATA_T = typename GRAPH_T::edata_t;
+  using VertexInfo = minigraph::graphs::VertexInfo<typename GRAPH_T::vid_t,
+                                                   typename GRAPH_T::vdata_t,
+                                                   typename GRAPH_T::edata_t>;
+
+ public:
+  WCCAutoMap() : minigraph::AutoMapBase<GRAPH_T, CONTEXT_T>() {}
+
+  // Push vdata from u to v.
+  bool F(const VertexInfo& u, VertexInfo& v,
+         GRAPH_T* graph = nullptr) override {
+    auto tag = false;
+    if (write_min(v.vdata, u.vdata[0])) tag = true;
+    return tag;
+  }
+
+  bool F(VertexInfo& u, GRAPH_T* graph = nullptr,
+         VID_T* vid_map = nullptr) override {
+    return false;
+  }
+
+  static bool kernel_init(GRAPH_T* graph, const size_t tid, Bitmap* visited,
+                          const size_t step) {
+    for (size_t i = tid; i < graph->get_num_vertexes(); i += step) {
+      auto u = graph->GetVertexByIndex(i);
+      graph->vdata_[i] = graph->localid2globalid(u.vid);
+    }
+    return true;
+  }
+};
+
+template <typename GRAPH_T, typename CONTEXT_T>
+class WCCPIE : public minigraph::AutoAppBase<GRAPH_T, CONTEXT_T> {
+  using VertexInfo = minigraph::graphs::VertexInfo<typename GRAPH_T::vid_t,
+                                                   typename GRAPH_T::vdata_t,
+                                                   typename GRAPH_T::edata_t>;
+
+ public:
+  WCCPIE(minigraph::AutoMapBase<GRAPH_T, CONTEXT_T>* auto_map,
+         const CONTEXT_T& context)
+      : minigraph::AutoAppBase<GRAPH_T, CONTEXT_T>(auto_map, context) {}
+
+  bool Init(GRAPH_T& graph,
+            minigraph::executors::TaskRunner* task_runner) override {
+    Bitmap* visited = new Bitmap(graph.max_vid_);
+    visited->fill();
+    this->auto_map_->ActiveMap(graph, task_runner, visited,
+                               WCCAutoMap<GRAPH_T, CONTEXT_T>::kernel_init);
+    delete visited;
+    return true;
+  }
+
+  bool PEval(GRAPH_T& graph,
+             minigraph::executors::TaskRunner* task_runner) override {
+    LOG_INFO("PEval() - Processing gid: ", graph.gid_,
+             " num_vertexes: ", graph.get_num_vertexes());
+    graph.ShowGraph(99);
+    if (!graph.IsInGraph(0)) return true;
+    auto vid_map = this->msg_mngr_->GetVidMap();
+    auto start_time = std::chrono::system_clock::now();
+
+    auto linkedlist_mutable_csr = new minigraph::graphs::LinkedListMutableCSR<
+        typename GRAPH_T::gid_t, typename GRAPH_T::vid_t,
+        typename GRAPH_T::vdata_t, typename GRAPH_T::edata_t>();
+
+    minigraph::utility::dynamic::SplitMerge<
+        typename GRAPH_T::gid_t, typename GRAPH_T::vid_t,
+        typename GRAPH_T::vdata_t, typename GRAPH_T::edata_t>
+        split_merge;
+
+    auto pair_graphs = split_merge.Split(graph);
+
+    auto graph_a = pair_graphs.first;
+    auto graph_b = pair_graphs.second;
+
+    LOG_INFO("X");
+    graph_a->ShowGraph(99);
+    LOG_INFO("X");
+    graph_b->ShowGraph(99);
+    LOG_INFO("X");
+
+    split_merge.Merge(linkedlist_mutable_csr, graph_a);
+    split_merge.Merge(linkedlist_mutable_csr, graph_b);
+
+    auto u = linkedlist_mutable_csr->GetVertexByVid(4);
+    u.ShowVertexInfo();
+
+    return true;
+  }
+
+  bool IncEval(GRAPH_T& graph,
+               minigraph::executors::TaskRunner* task_runner) override {
+   return false;
+  }
+
+  bool Aggregate(void* a, void* b,
+                 minigraph::executors::TaskRunner* task_runner) override {
+    if (a == nullptr || b == nullptr) return false;
+  }
+};
+
+struct Context {};
+
+using CSR_T = minigraph::graphs::ImmutableCSR<gid_t, vid_t, vdata_t, edata_t>;
+using WCCPIE_T = WCCPIE<CSR_T, Context>;
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  std::string work_space = FLAGS_i;
+  size_t num_workers_lc = FLAGS_lc;
+  size_t num_workers_cc = FLAGS_cc;
+  size_t num_workers_dc = FLAGS_dc;
+  size_t num_cores = FLAGS_cores;
+  size_t buffer_size = FLAGS_buffer_size;
+
+  Context context;
+  auto wcc_auto_map = new WCCAutoMap<CSR_T, Context>();
+  auto wcc_pie = new WCCPIE<CSR_T, Context>(wcc_auto_map, context);
+  auto app_wrapper =
+      new minigraph::AppWrapper<WCCPIE<CSR_T, Context>, CSR_T>(wcc_pie);
+
+  minigraph::MiniGraphSys<CSR_T, WCCPIE_T> minigraph_sys(
+      work_space, num_workers_lc, num_workers_cc, num_workers_dc, num_cores,
+      buffer_size, app_wrapper, FLAGS_mode, FLAGS_niters, FLAGS_scheduler);
+  minigraph_sys.RunSys();
+  gflags::ShutDownCommandLineFlags();
+  exit(0);
+}

--- a/minigraph/graphs/graph.h
+++ b/minigraph/graphs/graph.h
@@ -15,22 +15,22 @@
 namespace minigraph {
 namespace graphs {
 
-template<typename VID_T, typename VDATA_T, typename EDATA_T>
+template <typename VID_T, typename VDATA_T, typename EDATA_T>
 class VertexInfo {
  public:
   VID_T vid;
   size_t outdegree = 0;
   size_t indegree = 0;
-  VID_T *in_edges = nullptr;
-  VID_T *out_edges = nullptr;
-  VDATA_T *vdata = nullptr;
-  EDATA_T *edata = nullptr;
-  char *state = nullptr;
+  VID_T* in_edges = nullptr;
+  VID_T* out_edges = nullptr;
+  VDATA_T* vdata = nullptr;
+  EDATA_T* edata = nullptr;
+  char* state = nullptr;
 
   VertexInfo() = default;
   ~VertexInfo() = default;
 
-  void ShowVertexAbs(const VID_T &globalid = -1) const {
+  void ShowVertexAbs(const VID_T& globalid = -1) const {
     if (vdata == nullptr) {
       std::cout << " localid: " << vid << ", globalid: " << globalid
                 << ", outdegree: " << outdegree << ", indegree: " << indegree
@@ -41,7 +41,7 @@ class VertexInfo {
                 << ", indegree: " << indegree << std::endl;
     }
   }
-  void ShowVertexInfo(const VID_T &globalid = -1) const {
+  void ShowVertexInfo(const VID_T& globalid = -1) const {
     if (vdata == nullptr) {
       std::cout << " localid: " << vid << ", globalid: " << globalid
                 << ", outdegree: " << outdegree << ", indegree: " << indegree
@@ -88,7 +88,7 @@ class VertexInfo {
   }
 };
 
-template<typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
 class Graph {
  public:
   typedef VID_T vid_t;
@@ -109,7 +109,7 @@ class Graph {
 
   void InitVdata2AllX(const VDATA_T init_vdata = 0) {
     if (vdata_ == nullptr) {
-      vdata_ = (VDATA_T *) malloc(sizeof(VDATA_T) * get_num_vertexes());
+      vdata_ = (VDATA_T*)malloc(sizeof(VDATA_T) * get_num_vertexes());
       if (init_vdata != 0)
         for (size_t i = 0; i < this->get_num_vertexes(); i++)
           vdata_[i] = init_vdata;
@@ -125,7 +125,7 @@ class Graph {
 
   void InitVdataByVid() {
     if (vdata_ == nullptr) {
-      vdata_ = (VDATA_T *) malloc(sizeof(VDATA_T) * get_num_vertexes());
+      vdata_ = (VDATA_T*)malloc(sizeof(VDATA_T) * get_num_vertexes());
       memset(vdata_, 0, sizeof(VDATA_T) * this->get_num_vertexes());
       for (size_t i = 0; i < this->get_num_vertexes(); i++) vdata_[i] = i;
 
@@ -159,11 +159,11 @@ class Graph {
   VID_T max_vid_ = 0;
   VID_T aligned_max_vid_ = 0;
   size_t num_edges_ = 0;
-  VDATA_T *vdata_ = nullptr;
-  Bitmap *bitmap_ = nullptr;
-  VID_T *buf_graph_ = nullptr;
+  VDATA_T* vdata_ = nullptr;
+  Bitmap* bitmap_ = nullptr;
+  VID_T* buf_graph_ = nullptr;
 };
 
-}// namespace graphs
-}// namespace minigraph
-#endif// MINIGRAPH_GRAPHS_GRAPH_H
+}  // namespace graphs
+}  // namespace minigraph
+#endif  // MINIGRAPH_GRAPHS_GRAPH_H

--- a/minigraph/graphs/graph.h
+++ b/minigraph/graphs/graph.h
@@ -1,34 +1,36 @@
 #ifndef MINIGRAPH_GRAPHS_GRAPH_H
 #define MINIGRAPH_GRAPHS_GRAPH_H
 
-#include "portability/sys_types.h"
-#include "utility/bitmap.h"
-#include <folly/AtomicHashMap.h>
-#include <folly/FBString.h>
-#include <folly/Range.h>
 #include <iostream>
 #include <string>
 #include <unordered_map>
 
+#include <folly/AtomicHashMap.h>
+#include <folly/FBString.h>
+#include <folly/Range.h>
+
+#include "portability/sys_types.h"
+#include "utility/bitmap.h"
+
 namespace minigraph {
 namespace graphs {
 
-template <typename VID_T, typename VDATA_T, typename EDATA_T>
+template<typename VID_T, typename VDATA_T, typename EDATA_T>
 class VertexInfo {
  public:
   VID_T vid;
   size_t outdegree = 0;
   size_t indegree = 0;
-  VID_T* in_edges = nullptr;
-  VID_T* out_edges = nullptr;
-  VDATA_T* vdata = nullptr;
-  EDATA_T* edata = nullptr;
-  char* state = nullptr;
+  VID_T *in_edges = nullptr;
+  VID_T *out_edges = nullptr;
+  VDATA_T *vdata = nullptr;
+  EDATA_T *edata = nullptr;
+  char *state = nullptr;
 
   VertexInfo() = default;
   ~VertexInfo() = default;
 
-  void ShowVertexAbs(const VID_T& globalid = -1) const {
+  void ShowVertexAbs(const VID_T &globalid = -1) const {
     if (vdata == nullptr) {
       std::cout << " localid: " << vid << ", globalid: " << globalid
                 << ", outdegree: " << outdegree << ", indegree: " << indegree
@@ -39,7 +41,7 @@ class VertexInfo {
                 << ", indegree: " << indegree << std::endl;
     }
   }
-  void ShowVertexInfo(const VID_T& globalid = -1) const {
+  void ShowVertexInfo(const VID_T &globalid = -1) const {
     if (vdata == nullptr) {
       std::cout << " localid: " << vid << ", globalid: " << globalid
                 << ", outdegree: " << outdegree << ", indegree: " << indegree
@@ -86,7 +88,7 @@ class VertexInfo {
   }
 };
 
-template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+template<typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
 class Graph {
  public:
   typedef VID_T vid_t;
@@ -107,7 +109,7 @@ class Graph {
 
   void InitVdata2AllX(const VDATA_T init_vdata = 0) {
     if (vdata_ == nullptr) {
-      vdata_ = (VDATA_T*)malloc(sizeof(VDATA_T) * get_num_vertexes());
+      vdata_ = (VDATA_T *) malloc(sizeof(VDATA_T) * get_num_vertexes());
       if (init_vdata != 0)
         for (size_t i = 0; i < this->get_num_vertexes(); i++)
           vdata_[i] = init_vdata;
@@ -123,7 +125,7 @@ class Graph {
 
   void InitVdataByVid() {
     if (vdata_ == nullptr) {
-      vdata_ = (VDATA_T*)malloc(sizeof(VDATA_T) * get_num_vertexes());
+      vdata_ = (VDATA_T *) malloc(sizeof(VDATA_T) * get_num_vertexes());
       memset(vdata_, 0, sizeof(VDATA_T) * this->get_num_vertexes());
       for (size_t i = 0; i < this->get_num_vertexes(); i++) vdata_[i] = i;
 
@@ -138,6 +140,11 @@ class Graph {
 
   inline void set_num_edges(const size_t n) { num_edges_ = n; };
   inline void set_num_vertexes(const size_t n) { num_vertexes_ = n; };
+  inline void set_max_vid(const VID_T vid) {
+    max_vid_ = vid;
+    aligned_max_vid_ = ceil(max_vid_ / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR;
+  };
+
   inline GID_T get_gid() const { return gid_; }
   inline size_t get_num_vertexes() const { return num_vertexes_; }
   inline size_t get_num_edges() const { return num_edges_; }
@@ -152,11 +159,11 @@ class Graph {
   VID_T max_vid_ = 0;
   VID_T aligned_max_vid_ = 0;
   size_t num_edges_ = 0;
-  VDATA_T* vdata_ = nullptr;
-  Bitmap* bitmap_ = nullptr;
-  VID_T* buf_graph_ = nullptr;
+  VDATA_T *vdata_ = nullptr;
+  Bitmap *bitmap_ = nullptr;
+  VID_T *buf_graph_ = nullptr;
 };
 
-}  // namespace graphs
-}  // namespace minigraph
-#endif  // MINIGRAPH_GRAPHS_GRAPH_H
+}// namespace graphs
+}// namespace minigraph
+#endif// MINIGRAPH_GRAPHS_GRAPH_H

--- a/minigraph/graphs/graph.h
+++ b/minigraph/graphs/graph.h
@@ -1,16 +1,14 @@
 #ifndef MINIGRAPH_GRAPHS_GRAPH_H
 #define MINIGRAPH_GRAPHS_GRAPH_H
 
-#include <iostream>
-#include <string>
-#include <unordered_map>
-
+#include "portability/sys_types.h"
+#include "utility/bitmap.h"
 #include <folly/AtomicHashMap.h>
 #include <folly/FBString.h>
 #include <folly/Range.h>
-
-#include "portability/sys_types.h"
-#include "utility/bitmap.h"
+#include <iostream>
+#include <string>
+#include <unordered_map>
 
 namespace minigraph {
 namespace graphs {
@@ -99,15 +97,6 @@ class Graph {
   explicit Graph(GID_T gid) { gid_ = gid; }
   explicit Graph() {}
 
-  inline GID_T get_gid() const { return gid_; }
-  inline size_t get_num_vertexes() const { return num_vertexes_; }
-  inline size_t get_num_edges() const { return num_edges_; }
-  inline size_t get_max_vid() const { return max_vid_; }
-  inline size_t get_aligned_max_vid() const {
-    return ceil((float)aligned_max_vid_ / ALIGNMENT_FACTOR) *
-           ALIGNMENT_FACTOR;
-  }
-
   inline bool IsInGraph(const VID_T globalid) const {
     assert(bitmap_ != nullptr);
     if (globalid > bitmap_->size_) {
@@ -146,6 +135,16 @@ class Graph {
 
   virtual void CleanUp() = 0;
   virtual ~Graph() = default;
+
+  inline void set_num_edges(const size_t n) { num_edges_ = n; };
+  inline void set_num_vertexes(const size_t n) { num_vertexes_ = n; };
+  inline GID_T get_gid() const { return gid_; }
+  inline size_t get_num_vertexes() const { return num_vertexes_; }
+  inline size_t get_num_edges() const { return num_edges_; }
+  inline size_t get_max_vid() const { return max_vid_; }
+  inline size_t get_aligned_max_vid() const {
+    return ceil(aligned_max_vid_ / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR;
+  }
 
  public:
   GID_T gid_ = -1;

--- a/minigraph/graphs/immutable_csr.h
+++ b/minigraph/graphs/immutable_csr.h
@@ -425,14 +425,18 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     if (index != this->get_num_vertexes() - 1) {
       vertex_info->outdegree = outdegree_[index];
       vertex_info->indegree = indegree_[index];
-      vertex_info->in_edges = (in_edges_ + in_offset_[index]);
-      vertex_info->out_edges = (out_edges_ + out_offset_[index]);
+      //vertex_info->in_edges = (in_edges_ + in_offset_[index]);
+      //vertex_info->out_edges = (out_edges_ + out_offset_[index]);
+      vertex_info->in_edges = (in_edges_ + get_in_offset_by_index(index));
+      vertex_info->out_edges = (out_edges_ + get_out_offset_by_index(index));
       vertex_info->vdata = (this->vdata_ + index);
     } else {
       vertex_info->outdegree = outdegree_[index];
       vertex_info->indegree = indegree_[index];
-      vertex_info->in_edges = (in_edges_ + in_offset_[index]);
-      vertex_info->out_edges = (out_edges_ + out_offset_[index]);
+      //vertex_info->in_edges = (in_edges_ + in_offset_[index]);
+      //vertex_info->out_edges = (out_edges_ + out_offset_[index]);
+      vertex_info->in_edges = (in_edges_ + get_in_offset_by_index(index));
+      vertex_info->out_edges = (out_edges_ + get_out_offset_by_index(index));
       vertex_info->vdata = (this->vdata_ + index);
     }
     vertex_info->state = (vertexes_state_ + index);
@@ -447,14 +451,18 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     if (index != this->get_num_vertexes() - 1) {
       vertex_info.outdegree = outdegree_[index];
       vertex_info.indegree = indegree_[index];
-      vertex_info.in_edges = (in_edges_ + in_offset_[index]);
-      vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      //vertex_info.in_edges = (in_edges_ + in_offset_[index]);
+      //vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      vertex_info.in_edges = (in_edges_ + get_in_offset_by_index(index));
+      vertex_info.out_edges = (out_edges_ + get_out_offset_by_index(index));
       vertex_info.vdata = (this->vdata_ + index);
     } else {
       vertex_info.outdegree = outdegree_[index];
       vertex_info.indegree = indegree_[index];
-      vertex_info.in_edges = (in_edges_ + in_offset_[index]);
-      vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      //vertex_info.in_edges = (in_edges_ + in_offset_[index]);
+      //vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      vertex_info.in_edges = (in_edges_ + get_in_offset_by_index(index));
+      vertex_info.out_edges = (out_edges_ + get_out_offset_by_index(index));
       vertex_info.vdata = (this->vdata_ + index);
     }
     vertex_info.state = (vertexes_state_ + index);
@@ -535,6 +543,27 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     return;
   }
 
+
+  size_t get_num_in_edges() { return sum_in_edges_;  }
+
+  size_t get_num_out_edges() { return sum_out_edges_;  }
+
+  void set_num_in_edges(const size_t n) { sum_in_edges_ = n;  }
+
+  void set_num_out_edges(const size_t n) { sum_out_edges_ = n;  }
+
+  size_t get_out_offset_by_index(size_t i) {
+      return out_offset_[i] - out_offset_base_;
+  };
+
+  size_t get_in_offset_by_index(size_t i) {
+      return in_offset_[i] - in_offset_base_;
+  };
+
+  void set_out_offset_base(size_t base) { out_offset_base_ = base;  };
+
+  void set_in_offset_base(size_t base) { in_offset_base_ = base;  };
+
  public:
   size_t sum_in_edges_ = 0;
   size_t sum_out_edges_ = 0;
@@ -551,6 +580,9 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
   size_t* outdegree_ = nullptr;
   size_t* in_offset_ = nullptr;
   size_t* out_offset_ = nullptr;
+  
+  size_t in_offset_base_ = 0;
+  size_t out_offset_base_ = 0;
 
   char* vertexes_state_ = nullptr;
   std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>*>*

--- a/minigraph/graphs/immutable_csr.h
+++ b/minigraph/graphs/immutable_csr.h
@@ -1,10 +1,9 @@
 #ifndef MINIGRAPH_GRAPHS_IMMUTABLECSR_H
 #define MINIGRAPH_GRAPHS_IMMUTABLECSR_H
 
-#include <malloc.h>
-
 #include <fstream>
 #include <iostream>
+#include <malloc.h>
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -32,24 +31,24 @@
 namespace minigraph {
 namespace graphs {
 
-template<typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
 class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
   using VertexInfo = graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>;
 
  public:
   ImmutableCSR() : Graph<GID_T, VID_T, VDATA_T, EDATA_T>() {
     vertexes_info_ =
-        new std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> *>();
+        new std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>*>();
   };
 
   ImmutableCSR(const GID_T gid) : Graph<GID_T, VID_T, VDATA_T, EDATA_T>(gid){};
 
   ImmutableCSR(
       const GID_T gid,
-      graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> **set_vertexes = nullptr,
+      graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>** set_vertexes = nullptr,
       size_t num_vertexes = 0, const size_t sum_in_edges = 0,
       const size_t sum_out_edges = 0, const VID_T max_vid = 0,
-      VID_T *vid_map = nullptr)
+      VID_T* vid_map = nullptr)
       : Graph<GID_T, VID_T, VDATA_T, EDATA_T>(gid) {
     if (set_vertexes == nullptr) return;
     this->num_vertexes_ = num_vertexes;
@@ -57,7 +56,7 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     sum_out_edges_ = sum_out_edges;
     this->max_vid_ = max_vid;
     this->aligned_max_vid_ =
-        ceil((float) this->get_max_vid() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR;
+        ceil((float)this->get_max_vid() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR;
     this->bitmap_ = new Bitmap(this->get_aligned_max_vid());
     this->bitmap_->clear();
 
@@ -72,7 +71,9 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     size_t size_localid_by_globalid =
         sizeof(VID_T) * this->get_aligned_max_vid();
 
-    size_t total_size = size_globalid + size_indegree + size_outdegree + size_in_offset + size_out_offset + size_in_edges + size_out_edges + size_localid_by_globalid;
+    size_t total_size = size_globalid + size_indegree + size_outdegree +
+                        size_in_offset + size_out_offset + size_in_edges +
+                        size_out_edges + size_localid_by_globalid;
     size_t start_globalid = 0;
     size_t start_indegree = start_globalid + size_globalid;
     size_t start_outdegree = start_indegree + size_indegree;
@@ -82,9 +83,9 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     size_t start_out_edges = start_in_edges + size_in_edges;
     size_t start_localid_by_globalid = start_out_edges + size_out_edges;
 
-    this->vdata_ = (VDATA_T *) malloc(sizeof(VDATA_T) * num_vertexes);
+    this->vdata_ = (VDATA_T*)malloc(sizeof(VDATA_T) * num_vertexes);
     memset(this->vdata_, 0, sizeof(VDATA_T) * num_vertexes);
-    this->buf_graph_ = (VID_T *) malloc(total_size);
+    this->buf_graph_ = (VID_T*)malloc(total_size);
     memset(this->buf_graph_, 0, total_size);
 
     size_t count = 0;
@@ -94,43 +95,52 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
       if (set_vertexes[global_id] == nullptr) continue;
       if (vid_map != nullptr) vid_map[global_id] = local_id;
       this->bitmap_->set_bit(global_id);
-      ((VID_T *) ((char *) this->buf_graph_ + start_localid_by_globalid))[global_id] = local_id;
-      ((VID_T *) ((char *) this->buf_graph_ + start_globalid))[local_id] =
+      ((VID_T*)((char*)this->buf_graph_ +
+                start_localid_by_globalid))[global_id] = local_id;
+      ((VID_T*)((char*)this->buf_graph_ + start_globalid))[local_id] =
           global_id;
-      ((size_t *) ((char *) this->buf_graph_ + start_indegree))[local_id] =
+      ((size_t*)((char*)this->buf_graph_ + start_indegree))[local_id] =
           set_vertexes[global_id]->indegree;
-      ((size_t *) ((char *) this->buf_graph_ + start_outdegree))[local_id] =
+      ((size_t*)((char*)this->buf_graph_ + start_outdegree))[local_id] =
           set_vertexes[global_id]->outdegree;
       if (local_id == 0) {
-        ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[local_id] = 0;
+        ((size_t*)((char*)this->buf_graph_ + start_in_offset))[local_id] = 0;
         if (set_vertexes[global_id]->indegree > 0) {
-          memcpy((VID_T *) ((char *) this->buf_graph_ + start_in_edges),
+          memcpy((VID_T*)((char*)this->buf_graph_ + start_in_edges),
                  set_vertexes[global_id]->in_edges,
                  sizeof(VID_T) * set_vertexes[global_id]->indegree);
         }
-        ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[local_id] = 0;
+        ((size_t*)((char*)this->buf_graph_ + start_out_offset))[local_id] = 0;
         if (set_vertexes[global_id]->outdegree > 0) {
-          memcpy((VID_T *) ((char *) this->buf_graph_ + start_out_edges),
+          memcpy((VID_T*)((char*)this->buf_graph_ + start_out_edges),
                  set_vertexes[global_id]->out_edges,
                  sizeof(VID_T) * set_vertexes[global_id]->outdegree);
         }
       } else {
-        ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[local_id] =
-            ((size_t *) ((char *) this->buf_graph_ + start_indegree))[local_id - 1] + ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[local_id - 1];
+        ((size_t*)((char*)this->buf_graph_ + start_in_offset))[local_id] =
+            ((size_t*)((char*)this->buf_graph_ +
+                       start_indegree))[local_id - 1] +
+            ((size_t*)((char*)this->buf_graph_ +
+                       start_in_offset))[local_id - 1];
         if (set_vertexes[global_id]->indegree > 0) {
           size_t start =
-              ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[local_id];
-          memcpy(((char *) this->buf_graph_ + start_in_edges + start * sizeof(VID_T)),
+              ((size_t*)((char*)this->buf_graph_ + start_in_offset))[local_id];
+          memcpy(((char*)this->buf_graph_ + start_in_edges +
+                  start * sizeof(VID_T)),
                  set_vertexes[global_id]->in_edges,
                  sizeof(VID_T) * set_vertexes[global_id]->indegree);
         }
-        ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[local_id] =
-            ((size_t *) ((char *) this->buf_graph_ + start_outdegree))[local_id - 1] + ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[local_id - 1];
+        ((size_t*)((char*)this->buf_graph_ + start_out_offset))[local_id] =
+            ((size_t*)((char*)this->buf_graph_ +
+                       start_outdegree))[local_id - 1] +
+            ((size_t*)((char*)this->buf_graph_ +
+                       start_out_offset))[local_id - 1];
 
         if (set_vertexes[global_id]->outdegree > 0) {
           size_t start =
-              ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[local_id];
-          memcpy(((char *) this->buf_graph_ + start_out_edges + start * sizeof(VID_T)),
+              ((size_t*)((char*)this->buf_graph_ + start_out_offset))[local_id];
+          memcpy(((char*)this->buf_graph_ + start_out_edges +
+                  start * sizeof(VID_T)),
                  set_vertexes[global_id]->out_edges,
                  sizeof(VID_T) * set_vertexes[global_id]->outdegree);
         }
@@ -139,21 +149,21 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
       local_id++;
     }
 
-    globalid_by_index_ = (VID_T *) ((char *) this->buf_graph_ + start_globalid);
-    out_offset_ = (size_t *) ((char *) this->buf_graph_ + start_out_offset);
-    in_offset_ = (size_t *) ((char *) this->buf_graph_ + start_in_offset);
-    indegree_ = (size_t *) ((char *) this->buf_graph_ + start_indegree);
-    outdegree_ = (size_t *) ((char *) this->buf_graph_ + start_outdegree);
-    in_edges_ = (VID_T *) ((char *) this->buf_graph_ + start_in_edges);
-    out_edges_ = (VID_T *) ((char *) this->buf_graph_ + start_out_edges);
+    globalid_by_index_ = (VID_T*)((char*)this->buf_graph_ + start_globalid);
+    out_offset_ = (size_t*)((char*)this->buf_graph_ + start_out_offset);
+    in_offset_ = (size_t*)((char*)this->buf_graph_ + start_in_offset);
+    indegree_ = (size_t*)((char*)this->buf_graph_ + start_indegree);
+    outdegree_ = (size_t*)((char*)this->buf_graph_ + start_outdegree);
+    in_edges_ = (VID_T*)((char*)this->buf_graph_ + start_in_edges);
+    out_edges_ = (VID_T*)((char*)this->buf_graph_ + start_out_edges);
     localid_by_globalid_ =
-        (VID_T *) ((char *) this->buf_graph_ + start_localid_by_globalid);
+        (VID_T*)((char*)this->buf_graph_ + start_localid_by_globalid);
 
     this->num_edges_ = sum_in_edges_ + sum_out_edges_;
     this->gid_ = gid;
-    this->vdata_ = (VDATA_T *) malloc(sizeof(VDATA_T) * this->get_num_vertexes());
+    this->vdata_ = (VDATA_T*)malloc(sizeof(VDATA_T) * this->get_num_vertexes());
     memset(this->vdata_, 0, sizeof(VDATA_T) * this->get_num_vertexes());
-    vertexes_state_ = (char *) malloc(sizeof(char) * this->get_num_vertexes());
+    vertexes_state_ = (char*)malloc(sizeof(char) * this->get_num_vertexes());
     memset(vertexes_state_, VERTEXDISMATCH,
            sizeof(char) * this->get_num_vertexes());
 
@@ -162,7 +172,7 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
 
   ~ImmutableCSR() {
     if (vertexes_info_ != nullptr) {
-      std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> *> tmp;
+      std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>*> tmp;
       vertexes_info_->swap(tmp);
       delete vertexes_info_;
       vertexes_info_ = nullptr;
@@ -228,7 +238,7 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     }
     if (vertexes_info_ != nullptr) {
       LOG_INFO("Free vertexes_info: ", this->gid_);
-      std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> *> tmp;
+      std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>*> tmp;
       vertexes_info_->swap(tmp);
       delete vertexes_info_;
       vertexes_info_ = nullptr;
@@ -259,9 +269,10 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     size_t count_ = 0;
     for (size_t i = 0; i < this->get_num_vertexes(); i++) {
       if (count_++ > count) return;
-      VertexInfo &&vertex_info = GetVertexByIndex(i);
-      VID_T global_id = globalid_by_index_[i];
-      vertex_info.ShowVertexInfo(global_id);
+      VertexInfo&& vertex_info = GetVertexByIndex(i);
+      // VID_T global_id = globalid_by_index_[i];
+
+      vertex_info.ShowVertexInfo(globalid_by_index_[i]);
     }
     std::cout << std::endl;
     LOG_INFO("###########");
@@ -276,7 +287,7 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     size_t count_ = 0;
     for (size_t i = 0; i < this->get_num_vertexes(); i++) {
       if (count_++ > count) return;
-      VertexInfo &&vertex_info = GetVertexByIndex(i);
+      VertexInfo&& vertex_info = GetVertexByIndex(i);
       VID_T global_id = globalid_by_index_[i];
       vertex_info.ShowVertexAbs(global_id);
     }
@@ -297,7 +308,9 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     size_t size_out_edges = sizeof(VID_T) * sum_out_edges_;
     size_t size_index_by_vid = sizeof(size_t) * this->get_max_vid();
 
-    size_t total_size = size_localid + size_globalid + size_index_by_vid + size_indegree + size_outdegree + size_in_offset + size_out_offset + size_in_edges + size_out_edges;
+    size_t total_size = size_localid + size_globalid + size_index_by_vid +
+                        size_indegree + size_outdegree + size_in_offset +
+                        size_out_offset + size_in_edges + size_out_edges;
     size_t start_localid = 0;
     size_t start_globalid = start_localid + size_localid;
     size_t start_indegree = start_globalid + size_globalid;
@@ -308,73 +321,77 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     size_t start_out_edges = start_in_edges + size_in_edges;
     size_t start_localid_by_globalid = start_out_edges + size_out_edges;
 
-    this->vdata_ = (VDATA_T *) malloc(sizeof(VDATA_T) * this->get_num_vertexes());
+    this->vdata_ = (VDATA_T*)malloc(sizeof(VDATA_T) * this->get_num_vertexes());
     memset(this->vdata_, 0, sizeof(VDATA_T) * this->get_num_vertexes());
-    this->buf_graph_ = (VID_T *) malloc(total_size);
+    this->buf_graph_ = (VID_T*)malloc(total_size);
     memset(this->buf_graph_, 0, total_size);
     size_t i = 0;
-    for (auto &iter_vertex : *vertexes_info_) {
+    for (auto& iter_vertex : *vertexes_info_) {
       iter_vertex.second->ShowVertexInfo();
     }
-    for (auto &iter_vertex : *vertexes_info_) {
-      ((VID_T *) ((char *) this->buf_graph_ + start_localid))[i] =
+    for (auto& iter_vertex : *vertexes_info_) {
+      ((VID_T*)((char*)this->buf_graph_ + start_localid))[i] =
           iter_vertex.second->vid;
-      ((VID_T *) ((char *) this->buf_graph_ + start_globalid))[i] =
+      ((VID_T*)((char*)this->buf_graph_ + start_globalid))[i] =
           this->localid2globalid(iter_vertex.second->vid);
-      ((size_t *) ((char *) this->buf_graph_ + start_indegree))[i] =
+      ((size_t*)((char*)this->buf_graph_ + start_indegree))[i] =
           iter_vertex.second->indegree;
-      ((size_t *) ((char *) this->buf_graph_ + start_outdegree))[i] =
+      ((size_t*)((char*)this->buf_graph_ + start_outdegree))[i] =
           iter_vertex.second->outdegree;
       if (i == 0) {
-        ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[i] = 0;
+        ((size_t*)((char*)this->buf_graph_ + start_in_offset))[i] = 0;
         iter_vertex.second->ShowVertexInfo();
         if (iter_vertex.second->indegree > 0) {
-          memcpy((VID_T *) ((char *) this->buf_graph_ + start_in_edges),
+          memcpy((VID_T*)((char*)this->buf_graph_ + start_in_edges),
                  iter_vertex.second->in_edges,
                  sizeof(VID_T) * iter_vertex.second->indegree);
         }
-        ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[i] = 0;
+        ((size_t*)((char*)this->buf_graph_ + start_out_offset))[i] = 0;
         if (iter_vertex.second->outdegree > 0) {
-          memcpy((VID_T *) ((char *) this->buf_graph_ + start_out_edges),
+          memcpy((VID_T*)((char*)this->buf_graph_ + start_out_edges),
                  iter_vertex.second->out_edges,
                  sizeof(VID_T) * iter_vertex.second->outdegree);
         }
       } else {
-        ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[i] =
-            ((size_t *) ((char *) this->buf_graph_ + start_indegree))[i - 1] + ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[i - 1];
+        ((size_t*)((char*)this->buf_graph_ + start_in_offset))[i] =
+            ((size_t*)((char*)this->buf_graph_ + start_indegree))[i - 1] +
+            ((size_t*)((char*)this->buf_graph_ + start_in_offset))[i - 1];
         if (iter_vertex.second->indegree > 0) {
           size_t start =
-              ((size_t *) ((char *) this->buf_graph_ + start_in_offset))[i];
+              ((size_t*)((char*)this->buf_graph_ + start_in_offset))[i];
           iter_vertex.second->ShowVertexInfo();
-          memcpy(((char *) this->buf_graph_ + start_in_edges + start * sizeof(VID_T)),
+          memcpy(((char*)this->buf_graph_ + start_in_edges +
+                  start * sizeof(VID_T)),
                  iter_vertex.second->in_edges,
                  sizeof(VID_T) * iter_vertex.second->indegree);
         }
-        ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[i] =
-            ((size_t *) ((char *) this->buf_graph_ + start_outdegree))[i - 1] + ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[i - 1];
+        ((size_t*)((char*)this->buf_graph_ + start_out_offset))[i] =
+            ((size_t*)((char*)this->buf_graph_ + start_outdegree))[i - 1] +
+            ((size_t*)((char*)this->buf_graph_ + start_out_offset))[i - 1];
 
         if (iter_vertex.second->outdegree > 0) {
           size_t start =
-              ((size_t *) ((char *) this->buf_graph_ + start_out_offset))[i];
-          memcpy(((char *) this->buf_graph_ + start_out_edges + start * sizeof(VID_T)),
+              ((size_t*)((char*)this->buf_graph_ + start_out_offset))[i];
+          memcpy(((char*)this->buf_graph_ + start_out_edges +
+                  start * sizeof(VID_T)),
                  iter_vertex.second->out_edges,
                  sizeof(VID_T) * iter_vertex.second->outdegree);
         }
       }
       ++i;
     }
-    vid_by_index_ = ((VID_T *) ((char *) this->buf_graph_ + start_localid));
+    vid_by_index_ = ((VID_T*)((char*)this->buf_graph_ + start_localid));
     localid_by_globalid_ =
-        ((VID_T *) ((char *) this->buf_graph_ + start_localid_by_globalid));
-    globalid_by_index_ = (VID_T *) ((char *) this->buf_graph_ + start_globalid);
-    out_offset_ = (size_t *) ((char *) this->buf_graph_ + start_out_offset);
-    in_offset_ = (size_t *) ((char *) this->buf_graph_ + start_in_offset);
-    indegree_ = (size_t *) ((char *) this->buf_graph_ + start_indegree);
-    outdegree_ = (size_t *) ((char *) this->buf_graph_ + start_outdegree);
-    in_edges_ = (VID_T *) ((char *) this->buf_graph_ + start_in_edges);
-    out_edges_ = (VID_T *) ((char *) this->buf_graph_ + start_out_edges);
+        ((VID_T*)((char*)this->buf_graph_ + start_localid_by_globalid));
+    globalid_by_index_ = (VID_T*)((char*)this->buf_graph_ + start_globalid);
+    out_offset_ = (size_t*)((char*)this->buf_graph_ + start_out_offset);
+    in_offset_ = (size_t*)((char*)this->buf_graph_ + start_in_offset);
+    indegree_ = (size_t*)((char*)this->buf_graph_ + start_indegree);
+    outdegree_ = (size_t*)((char*)this->buf_graph_ + start_outdegree);
+    in_edges_ = (VID_T*)((char*)this->buf_graph_ + start_in_edges);
+    out_edges_ = (VID_T*)((char*)this->buf_graph_ + start_out_edges);
 
-    vertexes_state_ = (char *) malloc(sizeof(char) * this->get_num_vertexes());
+    vertexes_state_ = (char*)malloc(sizeof(char) * this->get_num_vertexes());
     memset(vertexes_state_, VERTEXDISMATCH,
            sizeof(char) * this->get_num_vertexes());
     is_serialized_ = true;
@@ -406,7 +423,7 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     return vertex_info;
   }
 
-  graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> *GetPVertexByIndex(
+  graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>* GetPVertexByIndex(
       const size_t index) {
     auto vertex_info = new graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>;
     vertex_info->vid = index;
@@ -449,7 +466,7 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     return vertex_info;
   }
 
-  graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> *GetPVertexByVid(
+  graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>* GetPVertexByVid(
       const VID_T vid) {
     auto vertex_info = new graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>;
     vertex_info->vid = vid;
@@ -477,10 +494,10 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     return globalid_by_index_[vid];
   }
 
-  //inline VID_T globalid2localid(const VID_T vid) const {
-  //  assert(localid_by_globalid_ != nullptr);
-  //  return localid_by_globalid_[vid];
-  // }
+  // inline VID_T globalid2localid(const VID_T vid) const {
+  //   assert(localid_by_globalid_ != nullptr);
+  //   return localid_by_globalid_[vid];
+  //  }
 
   inline VID_T globalid2localid(const VID_T globalid) const {
     return globalid - vid_base_;
@@ -492,8 +509,8 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
   // is_in_bucketX store those vertexes that belong to border vertexes for each
   // of fragment.
   // num_partitions is the number of total fragments
-  void SetGlobalBorderVidMap(Bitmap *global_border_vid_map = nullptr,
-                             Bitmap **is_in_bucketX = nullptr,
+  void SetGlobalBorderVidMap(Bitmap* global_border_vid_map = nullptr,
+                             Bitmap** is_in_bucketX = nullptr,
                              const size_t num_partitions = 1) {
     assert(global_border_vid_map != nullptr);
     assert(is_in_bucketX != nullptr);
@@ -501,13 +518,14 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
 
     LOG_INFO("SetGlobalBorderVidMap, GID: ", this->get_gid());
     for (VID_T local_id = 0; local_id < this->get_num_vertexes(); local_id++) {
-      graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> &&vertex_info =
+      graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>&& vertex_info =
           GetVertexByIndex(local_id);
       for (size_t i = 0; i < vertex_info.indegree; i++) {
         for (GID_T gid = 0; gid < num_partitions; gid++) {
           if (gid == this->get_gid()) continue;
           if (is_in_bucketX[gid] == nullptr) continue;
-          if (is_in_bucketX[gid]->get_bit(vertex_info.in_edges[i]) && global_border_vid_map->get_bit((vertex_info.in_edges[i])) == 0) {
+          if (is_in_bucketX[gid]->get_bit(vertex_info.in_edges[i]) &&
+              global_border_vid_map->get_bit((vertex_info.in_edges[i])) == 0) {
             global_border_vid_map->set_bit((vertex_info.in_edges[i]));
           }
         }
@@ -516,7 +534,8 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
         for (GID_T gid = 0; gid < num_partitions; gid++) {
           if (gid == this->get_gid()) continue;
           if (is_in_bucketX[gid] == nullptr) continue;
-          if (is_in_bucketX[gid]->get_bit(vertex_info.out_edges[i]) && global_border_vid_map->get_bit((vertex_info.out_edges[i])) == 0) {
+          if (is_in_bucketX[gid]->get_bit(vertex_info.out_edges[i]) &&
+              global_border_vid_map->get_bit((vertex_info.out_edges[i])) == 0) {
             global_border_vid_map->set_bit((vertex_info.out_edges[i]));
           }
         }
@@ -550,25 +569,25 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
   bool is_serialized_ = false;
 
   // serialized data in CSR format.
-  VID_T *vid_by_index_ = nullptr;
-  VID_T *localid_by_globalid_ = nullptr;
-  VID_T *globalid_by_index_ = nullptr;
-  VID_T *in_edges_ = nullptr;
-  VID_T *out_edges_ = nullptr;
-  size_t *indegree_ = nullptr;
-  size_t *outdegree_ = nullptr;
-  size_t *in_offset_ = nullptr;
-  size_t *out_offset_ = nullptr;
+  VID_T* vid_by_index_ = nullptr;
+  VID_T* localid_by_globalid_ = nullptr;
+  VID_T* globalid_by_index_ = nullptr;
+  VID_T* in_edges_ = nullptr;
+  VID_T* out_edges_ = nullptr;
+  size_t* indegree_ = nullptr;
+  size_t* outdegree_ = nullptr;
+  size_t* in_offset_ = nullptr;
+  size_t* out_offset_ = nullptr;
 
   size_t in_offset_base_ = 0;
   size_t out_offset_base_ = 0;
   VID_T vid_base_ = 0;
 
-  char *vertexes_state_ = nullptr;
-  std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> *> *
+  char* vertexes_state_ = nullptr;
+  std::map<VID_T, graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>*>*
       vertexes_info_ = nullptr;
 };
 
-}// namespace graphs
-}// namespace minigraph
-#endif// MINIGRAPH_GRAPHS_IMMUTABLECSR_H
+}  // namespace graphs
+}  // namespace minigraph
+#endif  // MINIGRAPH_GRAPHS_IMMUTABLECSR_H

--- a/minigraph/graphs/immutable_csr.h
+++ b/minigraph/graphs/immutable_csr.h
@@ -1,13 +1,15 @@
 #ifndef MINIGRAPH_GRAPHS_IMMUTABLECSR_H
 #define MINIGRAPH_GRAPHS_IMMUTABLECSR_H
 
+#include <malloc.h>
+
 #include <fstream>
 #include <iostream>
-#include <malloc.h>
 #include <map>
 #include <memory>
 #include <unordered_map>
 
+#include <jemalloc/jemalloc.h>
 #include <folly/AtomicHashArray.h>
 #include <folly/AtomicHashMap.h>
 #include <folly/AtomicUnorderedMap.h>
@@ -19,7 +21,6 @@
 #include <folly/portability/Asm.h>
 #include <folly/portability/Atomic.h>
 #include <folly/portability/SysTime.h>
-#include <jemalloc/jemalloc.h>
 
 #include "graphs/edge_list.h"
 #include "graphs/graph.h"
@@ -404,14 +405,18 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     if (index != this->get_num_vertexes() - 1) {
       vertex_info.outdegree = outdegree_[index];
       vertex_info.indegree = indegree_[index];
-      vertex_info.in_edges = (in_edges_ + in_offset_[index]);
-      vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      // vertex_info.in_edges = (in_edges_ + in_offset_[index]);
+      // vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      vertex_info.in_edges = (in_edges_ + get_in_offset_by_index(index));
+      vertex_info.out_edges = (out_edges_ + get_out_offset_by_index(index));
       vertex_info.vdata = (this->vdata_ + index);
     } else {
       vertex_info.outdegree = outdegree_[index];
       vertex_info.indegree = indegree_[index];
-      vertex_info.in_edges = (in_edges_ + in_offset_[index]);
-      vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      // vertex_info.in_edges = (in_edges_ + in_offset_[index]);
+      // vertex_info.out_edges = (out_edges_ + out_offset_[index]);
+      vertex_info.in_edges = (in_edges_ + get_in_offset_by_index(index));
+      vertex_info.out_edges = (out_edges_ + get_out_offset_by_index(index));
       vertex_info.vdata = (this->vdata_ + index);
     }
     vertex_info.state = (vertexes_state_ + index);
@@ -425,18 +430,14 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     if (index != this->get_num_vertexes() - 1) {
       vertex_info->outdegree = outdegree_[index];
       vertex_info->indegree = indegree_[index];
-      //vertex_info->in_edges = (in_edges_ + in_offset_[index]);
-      //vertex_info->out_edges = (out_edges_ + out_offset_[index]);
-      vertex_info->in_edges = (in_edges_ + get_in_offset_by_index(index));
-      vertex_info->out_edges = (out_edges_ + get_out_offset_by_index(index));
+      vertex_info->in_edges = (in_edges_ + in_offset_[index]);
+      vertex_info->out_edges = (out_edges_ + out_offset_[index]);
       vertex_info->vdata = (this->vdata_ + index);
     } else {
       vertex_info->outdegree = outdegree_[index];
       vertex_info->indegree = indegree_[index];
-      //vertex_info->in_edges = (in_edges_ + in_offset_[index]);
-      //vertex_info->out_edges = (out_edges_ + out_offset_[index]);
-      vertex_info->in_edges = (in_edges_ + get_in_offset_by_index(index));
-      vertex_info->out_edges = (out_edges_ + get_out_offset_by_index(index));
+      vertex_info->in_edges = (in_edges_ + in_offset_[index]);
+      vertex_info->out_edges = (out_edges_ + out_offset_[index]);
       vertex_info->vdata = (this->vdata_ + index);
     }
     vertex_info->state = (vertexes_state_ + index);
@@ -451,18 +452,14 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     if (index != this->get_num_vertexes() - 1) {
       vertex_info.outdegree = outdegree_[index];
       vertex_info.indegree = indegree_[index];
-      //vertex_info.in_edges = (in_edges_ + in_offset_[index]);
-      //vertex_info.out_edges = (out_edges_ + out_offset_[index]);
-      vertex_info.in_edges = (in_edges_ + get_in_offset_by_index(index));
-      vertex_info.out_edges = (out_edges_ + get_out_offset_by_index(index));
+      vertex_info.in_edges = (in_edges_ + in_offset_[index]);
+      vertex_info.out_edges = (out_edges_ + out_offset_[index]);
       vertex_info.vdata = (this->vdata_ + index);
     } else {
       vertex_info.outdegree = outdegree_[index];
       vertex_info.indegree = indegree_[index];
-      //vertex_info.in_edges = (in_edges_ + in_offset_[index]);
-      //vertex_info.out_edges = (out_edges_ + out_offset_[index]);
-      vertex_info.in_edges = (in_edges_ + get_in_offset_by_index(index));
-      vertex_info.out_edges = (out_edges_ + get_out_offset_by_index(index));
+      vertex_info.in_edges = (in_edges_ + in_offset_[index]);
+      vertex_info.out_edges = (out_edges_ + out_offset_[index]);
       vertex_info.vdata = (this->vdata_ + index);
     }
     vertex_info.state = (vertexes_state_ + index);
@@ -543,26 +540,20 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     return;
   }
 
+  size_t get_num_in_edges() { return sum_in_edges_; }
+  size_t get_num_out_edges() { return sum_out_edges_; }
 
-  size_t get_num_in_edges() { return sum_in_edges_;  }
-
-  size_t get_num_out_edges() { return sum_out_edges_;  }
-
-  void set_num_in_edges(const size_t n) { sum_in_edges_ = n;  }
-
-  void set_num_out_edges(const size_t n) { sum_out_edges_ = n;  }
+  void set_num_in_edges(const size_t n) { sum_in_edges_ = n; }
+  void set_num_out_edges(const size_t n) { sum_out_edges_ = n; }
 
   size_t get_out_offset_by_index(size_t i) {
-      return out_offset_[i] - out_offset_base_;
+    return out_offset_[i] - out_offset_base_;
   };
-
   size_t get_in_offset_by_index(size_t i) {
-      return in_offset_[i] - in_offset_base_;
+    return in_offset_[i] - in_offset_base_;
   };
-
-  void set_out_offset_base(size_t base) { out_offset_base_ = base;  };
-
-  void set_in_offset_base(size_t base) { in_offset_base_ = base;  };
+  void set_out_offset_base(size_t base) { out_offset_base_ = base; };
+  void set_in_offset_base(size_t base) { in_offset_base_ = base; };
 
  public:
   size_t sum_in_edges_ = 0;
@@ -580,7 +571,7 @@ class ImmutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
   size_t* outdegree_ = nullptr;
   size_t* in_offset_ = nullptr;
   size_t* out_offset_ = nullptr;
-  
+
   size_t in_offset_base_ = 0;
   size_t out_offset_base_ = 0;
 

--- a/minigraph/graphs/linked_list_mutable_csr.h
+++ b/minigraph/graphs/linked_list_mutable_csr.h
@@ -1,0 +1,96 @@
+#ifndef MINIGRAPH_GRAPHS_LINKEDLISTMUTABLECSR_H
+#define MINIGRAPH_GRAPHS_LINKEDLISTMUTABLECSR_H
+
+#include <malloc.h>
+
+#include "graphs/graph.h"
+#include "immutable_csr.h"
+#include "portability/sys_data_structure.h"
+#include "portability/sys_types.h"
+#include "utility/bitmap.h"
+#include "utility/logging.h"
+
+namespace minigraph {
+namespace graphs {
+
+// A mutable CSR implementation.
+//
+// It organized several graphs that in ImmutableCSR format into a LinkedList.
+// It allows user to search a vertex with global_id in linked graphs.
+template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+class LinkedListMutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
+  using VertexInfo = graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>;
+
+ public:
+  struct LinkedList {
+    ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>* p_graphs = nullptr;
+    LinkedList* next = nullptr;
+  }* linked_list_ = nullptr;
+
+  LinkedListMutableCSR() : Graph<GID_T, VID_T, VDATA_T, EDATA_T>() {
+    linked_list_ = new LinkedList();
+  };
+
+  ~LinkedListMutableCSR() {}
+  void CleanUp() override { return; }
+
+  size_t get_num_graphs() { return num_graphs_; }
+  void set_num_graphs(size_t num_graphs) { num_graphs_ = num_graphs; }
+
+  // Append a new graph im ImmutableCSR format to the trail of linked_list.
+  void GraphAppend(
+      ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>* immutable_csr) {
+    if (num_graphs_ == 0) {
+      num_graphs_ = 1;
+      linked_list_->p_graphs = immutable_csr;
+      linked_list_->next = new LinkedList;
+    } else {
+      auto next = linked_list_;
+      while (next->next != nullptr) {
+        next = next->next;
+      }
+      next->p_graphs = immutable_csr;
+      next->next = new LinkedList;
+      ++num_graphs_;
+    }
+    return;
+  }
+
+  VID_T get_localid(VID_T global_id) {
+    auto next = linked_list_;
+    auto local_id = global_id;
+    while (next->next != nullptr) {
+      if (next->p_graphs->get_num_vertexes() <= local_id) {
+        local_id -= next->p_graphs->get_num_vertexes();
+        next = next->next;
+      } else {
+        break;
+      }
+    }
+    return local_id;
+  }
+
+  // Get a vertexinfo by globalid.
+  graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> GetVertexByVid(
+      const VID_T globalid) {
+    VID_T localid = get_localid(globalid);
+    auto next = linked_list_;
+    graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>* p = nullptr;
+    while (next->next != nullptr) {
+      if (next->p_graphs &&
+          next->p_graphs->globalid_by_index_[localid] != globalid) {
+        next = next->next;
+      } else {
+        break;
+      }
+    }
+    return next->p_graphs->GetVertexByVid(localid);
+  }
+
+ private:
+  size_t num_graphs_ = 0;
+};
+
+}  // namespace graphs
+}  // namespace minigraph
+#endif  // MINIGRAPH_GRAPHS_LINKEDLISTMUTABLECSR_H

--- a/minigraph/graphs/linked_list_mutable_csr.h
+++ b/minigraph/graphs/linked_list_mutable_csr.h
@@ -17,15 +17,15 @@ namespace graphs {
 //
 // It organized several graphs that in ImmutableCSR format into a LinkedList.
 // It allows user to search a vertex with global_id in linked graphs.
-template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+template<typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
 class LinkedListMutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
   using VertexInfo = graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>;
 
  public:
   struct LinkedList {
-    ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>* p_graphs = nullptr;
-    LinkedList* next = nullptr;
-  }* linked_list_ = nullptr;
+    ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *p_graphs = nullptr;
+    LinkedList *next = nullptr;
+  } *linked_list_ = nullptr;
 
   LinkedListMutableCSR() : Graph<GID_T, VID_T, VDATA_T, EDATA_T>() {
     linked_list_ = new LinkedList();
@@ -39,7 +39,7 @@ class LinkedListMutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
 
   // Append a new graph im ImmutableCSR format to the trail of linked_list.
   void GraphAppend(
-      ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>* immutable_csr) {
+      ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *immutable_csr) {
     if (num_graphs_ == 0) {
       num_graphs_ = 1;
       linked_list_->p_graphs = immutable_csr;
@@ -56,31 +56,17 @@ class LinkedListMutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
     return;
   }
 
-  VID_T get_localid(VID_T global_id) {
-    auto next = linked_list_;
-    auto local_id = global_id;
-    while (next->next != nullptr) {
-      if (next->p_graphs->get_num_vertexes() <= local_id) {
-        local_id -= next->p_graphs->get_num_vertexes();
-        next = next->next;
-      } else {
-        break;
-      }
-    }
-    return local_id;
-  }
-
   // Get a vertexinfo by globalid.
   graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> GetVertexByVid(
       const VID_T globalid) {
-    VID_T localid = get_localid(globalid);
+    VID_T localid = 0;
     auto next = linked_list_;
-    graphs::VertexInfo<VID_T, VDATA_T, EDATA_T>* p = nullptr;
+    graphs::VertexInfo<VID_T, VDATA_T, EDATA_T> *p = nullptr;
     while (next->next != nullptr) {
-      if (next->p_graphs &&
-          next->p_graphs->globalid_by_index_[localid] != globalid) {
+      if (next->p_graphs && globalid > next->p_graphs->get_max_vid()) {
         next = next->next;
       } else {
+        localid = next->p_graphs->globalid2localid(globalid);
         break;
       }
     }
@@ -91,6 +77,6 @@ class LinkedListMutableCSR : public Graph<GID_T, VID_T, VDATA_T, EDATA_T> {
   size_t num_graphs_ = 0;
 };
 
-}  // namespace graphs
-}  // namespace minigraph
-#endif  // MINIGRAPH_GRAPHS_LINKEDLISTMUTABLECSR_H
+}// namespace graphs
+}// namespace minigraph
+#endif// MINIGRAPH_GRAPHS_LINKEDLISTMUTABLECSR_H

--- a/minigraph/portability/sys_types.h
+++ b/minigraph/portability/sys_types.h
@@ -13,7 +13,7 @@ using edata_t = size_t;
 #define VDATA_MAX 0XFFFFFFF
 #define GID_MAX 0XFFFFFFF
 #define MINIGRAPH_GID_MAX (((unsigned)(-1)) >> 1)
-#define ALIGNMENT_FACTOR 1024
+#define ALIGNMENT_FACTOR 1024.0
 #define NUM_NEW_BUCKETS 1
 
 

--- a/minigraph/utility/dynamic/split_merge.h
+++ b/minigraph/utility/dynamic/split_merge.h
@@ -8,7 +8,7 @@ namespace minigraph {
 namespace utility {
 namespace dynamic {
 
-template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+template<typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
 class SplitMerge {
  public:
   SplitMerge() = default;
@@ -16,9 +16,9 @@ class SplitMerge {
 
   // Split the ImmutableCSR graph into two fragments graph_a and graph_b, such
   // that they are approximately equal in num of edges.
-  std::pair<graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*,
-            graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*>
-  Split(graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>& immutable_csr) {
+  std::pair<graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *,
+            graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *>
+  Split(graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> &immutable_csr) {
     auto graph_a = new graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>;
     auto graph_b = new graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>;
 
@@ -38,49 +38,39 @@ class SplitMerge {
       else
         break;
     }
-    LOG_INFO("X", i);
 
     // Construct graph_a
     graph_a->set_num_vertexes(i);
-    graph_a->vdata_ = (VDATA_T*)malloc(
-        sizeof(VDATA_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_a->globalid_by_index_ = (VID_T*)malloc(
-        sizeof(VID_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
+    graph_a->vdata_ = (VDATA_T *) malloc(
+        sizeof(VDATA_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_a->globalid_by_index_ = (VID_T *) malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
 
     memcpy(graph_a->globalid_by_index_, immutable_csr.globalid_by_index_,
            sizeof(VID_T) * graph_a->get_num_vertexes());
 
-    graph_a->set_num_out_edges(immutable_csr.out_offset_[i] +
-                               immutable_csr.outdegree_[i]);
-    graph_a->out_offset_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_a->outdegree_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_a->out_edges_ = (VID_T*)malloc(
-        sizeof(VID_T) * ceil(graph_a->get_num_out_edges() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    memcpy(graph_a->out_edges_, immutable_csr.out_edges_,
-           sizeof(VID_T) * graph_a->get_num_out_edges());
+    graph_a->set_num_out_edges(immutable_csr.out_offset_[i] + immutable_csr.outdegree_[i]);
+    graph_a->out_offset_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_a->outdegree_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_a->out_edges_ = (VID_T *) malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_out_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+
     memcpy(graph_a->out_offset_, immutable_csr.out_offset_,
            sizeof(size_t) * graph_a->get_num_vertexes());
     memcpy(graph_a->outdegree_, immutable_csr.outdegree_,
            sizeof(size_t) * graph_a->get_num_vertexes());
+    memcpy(graph_a->out_edges_, immutable_csr.out_edges_,
+           sizeof(VID_T) * graph_a->get_num_out_edges());
 
-    graph_a->set_num_in_edges(immutable_csr.in_offset_[i] +
-                              immutable_csr.indegree_[i]);
-    graph_a->in_offset_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_a->indegree_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_a->in_edges_ = (VID_T*)malloc(
-        sizeof(VID_T) * ceil(graph_a->get_num_in_edges() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
+    graph_a->set_num_in_edges(immutable_csr.in_offset_[i] + immutable_csr.indegree_[i]);
+    graph_a->in_offset_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_a->indegree_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_a->in_edges_ = (VID_T *) malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_in_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
     memcpy(graph_a->in_edges_, immutable_csr.in_edges_,
            sizeof(VID_T) * graph_a->get_num_in_edges());
     memcpy(graph_a->in_offset_, immutable_csr.in_offset_,
@@ -91,29 +81,22 @@ class SplitMerge {
            sizeof(VID_T) * graph_a->get_num_vertexes());
 
     // Construct graph_b
-    graph_b->set_num_vertexes(immutable_csr.get_num_vertexes() -
-                              graph_a->get_num_vertexes());
-    graph_b->vdata_ = (VDATA_T*)malloc(
-        sizeof(VDATA_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_b->globalid_by_index_ = (VID_T*)malloc(
-        sizeof(VID_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
+    graph_b->set_num_vertexes(immutable_csr.get_num_vertexes() - graph_a->get_num_vertexes());
+    graph_b->vdata_ = (VDATA_T *) malloc(
+        sizeof(VDATA_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_b->globalid_by_index_ = (VID_T *) malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
 
     memcpy(graph_b->globalid_by_index_, immutable_csr.globalid_by_index_ + i,
            sizeof(VID_T) * graph_b->get_num_vertexes());
 
-    graph_b->set_num_out_edges(immutable_csr.get_num_out_edges() -
-                               immutable_csr.out_offset_[i]);
-    graph_b->out_offset_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_b->outdegree_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_b->out_edges_ = (VID_T*)malloc(
-        sizeof(VID_T) * ceil(graph_b->get_num_out_edges() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
+    graph_b->set_num_out_edges(immutable_csr.get_num_out_edges() - immutable_csr.out_offset_[i]);
+    graph_b->out_offset_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_b->outdegree_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_b->out_edges_ = (VID_T *) malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_out_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
 
     memcpy(graph_b->out_edges_,
            immutable_csr.out_edges_ + immutable_csr.out_offset_[i],
@@ -123,17 +106,13 @@ class SplitMerge {
     memcpy(graph_b->outdegree_, immutable_csr.outdegree_ + i,
            sizeof(size_t) * graph_b->get_num_vertexes());
 
-    graph_b->set_num_in_edges(immutable_csr.get_num_in_edges() -
-                              immutable_csr.in_offset_[i]);
-    graph_b->in_offset_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_b->indegree_ = (size_t*)malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
-    graph_b->in_edges_ = (VID_T*)malloc(
-        sizeof(VID_T) * ceil(graph_b->get_num_in_edges() / ALIGNMENT_FACTOR) *
-        ALIGNMENT_FACTOR);
+    graph_b->set_num_in_edges(immutable_csr.get_num_in_edges() - immutable_csr.in_offset_[i]);
+    graph_b->in_offset_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_b->indegree_ = (size_t *) malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_b->in_edges_ = (VID_T *) malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_in_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
     memcpy(graph_b->in_edges_,
            immutable_csr.in_edges_ + immutable_csr.in_offset_[i],
            sizeof(VID_T) * graph_b->get_num_in_edges());
@@ -144,18 +123,22 @@ class SplitMerge {
     memcpy(graph_b->vdata_, immutable_csr.vdata_ + i,
            sizeof(VID_T) * graph_b->get_num_vertexes());
 
-    graph_b->set_in_offset_base(immutable_csr.in_offset_[i]);
-    graph_b->set_out_offset_base(immutable_csr.out_offset_[i]);
     graph_a->set_in_offset_base(0);
     graph_a->set_out_offset_base(0);
+    graph_a->set_vid_base(immutable_csr.get_vid_base());
+    graph_a->set_max_vid(i - 1);
+    graph_b->set_in_offset_base(immutable_csr.in_offset_[i]);
+    graph_b->set_out_offset_base(immutable_csr.out_offset_[i]);
+    graph_b->set_vid_base(i);
+    graph_b->set_max_vid(immutable_csr.get_max_vid());
 
     return std::make_pair(graph_a, graph_b);
   }
 
   // Append a new graph im ImmutableCSR format to the trail of linked_list.
-  void Merge(graphs::LinkedListMutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*
+  void Merge(graphs::LinkedListMutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *
                  linkedlist_mutable_csr = nullptr,
-             graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*
+             graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *
                  immutable_csr = nullptr) {
     assert(linkedlist_mutable_csr != nullptr && immutable_csr != nullptr);
 
@@ -164,7 +147,7 @@ class SplitMerge {
   }
 };
 
-}  // namespace dynamic
-}  // namespace utility
-}  // namespace minigraph
-#endif  // ATOMIC_H_SPLIT_MERGE_H
+}// namespace dynamic
+}// namespace utility
+}// namespace minigraph
+#endif// ATOMIC_H_SPLIT_MERGE_H

--- a/minigraph/utility/dynamic/split_merge.h
+++ b/minigraph/utility/dynamic/split_merge.h
@@ -38,7 +38,7 @@ class SplitMerge {
       else
         break;
     }
-    LOG_INFO("i", i);
+    LOG_INFO("X", i);
 
     // Construct graph_a
     graph_a->set_num_vertexes(i);

--- a/minigraph/utility/dynamic/split_merge.h
+++ b/minigraph/utility/dynamic/split_merge.h
@@ -8,7 +8,7 @@ namespace minigraph {
 namespace utility {
 namespace dynamic {
 
-template<typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
 class SplitMerge {
  public:
   SplitMerge() = default;
@@ -16,47 +16,64 @@ class SplitMerge {
 
   // Split the ImmutableCSR graph into two fragments graph_a and graph_b, such
   // that they are approximately equal in num of edges.
-  std::pair<graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *,
-            graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *>
-  Split(graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> &immutable_csr) {
+  std::pair<graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*,
+            graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*>
+  Split(graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>& immutable_csr) {
     auto graph_a = new graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>;
     auto graph_b = new graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>;
 
-    size_t tmp_base = immutable_csr.get_num_out_edges() / 2;
-
     // Binary search for splitted poit.
-    size_t i = immutable_csr.get_num_vertexes() / 2;
-    size_t end = immutable_csr.get_num_vertexes();
+    size_t i = (immutable_csr.get_max_vid() - immutable_csr.get_vid_base()) / 2;
+    size_t end = immutable_csr.get_max_vid() - immutable_csr.get_vid_base();
     size_t start = 0;
+    size_t tmp_base =
+        (immutable_csr.out_offset_[immutable_csr.get_num_vertexes() - 1] +
+         immutable_csr.outdegree_[immutable_csr.get_num_vertexes() - 1] -
+         immutable_csr.out_offset_[0]) /
+        2;
 
     while (start <= end) {
-      i = start + (end - start) / 2;
-      if (immutable_csr.out_offset_[i] < tmp_base)
+      i = ceil(end - start) / 2;
+      if (immutable_csr.out_offset_[i] - immutable_csr.out_offset_[0] +
+              immutable_csr.outdegree_[i] <
+          tmp_base)
         start = i + 1;
-      else if (immutable_csr.out_offset_[i] > tmp_base)
+      else if (immutable_csr.out_offset_[i] - immutable_csr.out_offset_[0] >
+               tmp_base)
         end = i - 1;
-      else
+      else {
         break;
+      }
     }
 
     // Construct graph_a
-    graph_a->set_num_vertexes(i);
-    graph_a->vdata_ = (VDATA_T *) malloc(
-        sizeof(VDATA_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_a->globalid_by_index_ = (VID_T *) malloc(
-        sizeof(VID_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-
+    graph_a->set_num_vertexes(i + 1);
+    graph_a->vdata_ = (VDATA_T*)malloc(
+        sizeof(VDATA_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->globalid_by_index_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
     memcpy(graph_a->globalid_by_index_, immutable_csr.globalid_by_index_,
            sizeof(VID_T) * graph_a->get_num_vertexes());
 
-    graph_a->set_num_out_edges(immutable_csr.out_offset_[i] + immutable_csr.outdegree_[i]);
-    graph_a->out_offset_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_a->outdegree_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_a->out_edges_ = (VID_T *) malloc(
-        sizeof(VID_T) * ceil(graph_a->get_num_out_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-
+    graph_a->set_num_out_edges(immutable_csr.out_offset_[i] +
+                               immutable_csr.outdegree_[i] -
+                               immutable_csr.out_offset_[0]);
+    graph_a->out_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->outdegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->out_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_out_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    memset(graph_a->out_offset_, 0,
+           sizeof(size_t) * graph_a->get_num_vertexes());
+    memset(graph_a->outdegree_, 0,
+           sizeof(size_t) * graph_a->get_num_vertexes());
+    memset(graph_a->out_edges_, 0, sizeof(VID_T) * graph_a->get_num_edges());
     memcpy(graph_a->out_offset_, immutable_csr.out_offset_,
            sizeof(size_t) * graph_a->get_num_vertexes());
     memcpy(graph_a->outdegree_, immutable_csr.outdegree_,
@@ -64,13 +81,23 @@ class SplitMerge {
     memcpy(graph_a->out_edges_, immutable_csr.out_edges_,
            sizeof(VID_T) * graph_a->get_num_out_edges());
 
-    graph_a->set_num_in_edges(immutable_csr.in_offset_[i] + immutable_csr.indegree_[i]);
-    graph_a->in_offset_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_a->indegree_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_a->in_edges_ = (VID_T *) malloc(
-        sizeof(VID_T) * ceil(graph_a->get_num_in_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_a->set_num_in_edges(immutable_csr.in_offset_[i] +
+                              immutable_csr.indegree_[i] -
+                              immutable_csr.in_offset_[0]);
+    graph_a->in_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->indegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->in_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_in_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    memset(graph_a->in_offset_, 0,
+           sizeof(size_t) * graph_a->get_num_vertexes());
+    memset(graph_a->indegree_, 0, sizeof(size_t) * graph_a->get_num_vertexes());
+    memset(graph_a->in_edges_, 0, sizeof(VID_T) * graph_a->get_num_edges());
+
     memcpy(graph_a->in_edges_, immutable_csr.in_edges_,
            sizeof(VID_T) * graph_a->get_num_in_edges());
     memcpy(graph_a->in_offset_, immutable_csr.in_offset_,
@@ -80,65 +107,94 @@ class SplitMerge {
     memcpy(graph_a->vdata_, immutable_csr.vdata_,
            sizeof(VID_T) * graph_a->get_num_vertexes());
 
-    // Construct graph_b
-    graph_b->set_num_vertexes(immutable_csr.get_num_vertexes() - graph_a->get_num_vertexes());
-    graph_b->vdata_ = (VDATA_T *) malloc(
-        sizeof(VDATA_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_b->globalid_by_index_ = (VID_T *) malloc(
-        sizeof(VID_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_a->set_in_offset_base(immutable_csr.in_offset_[0]);
+    graph_a->set_out_offset_base(immutable_csr.out_offset_[0]);
+    graph_a->set_vid_base(immutable_csr.localid2globalid(0));
+    graph_a->set_max_vid(graph_a->localid2globalid(i));
 
-    memcpy(graph_b->globalid_by_index_, immutable_csr.globalid_by_index_ + i,
+    // Construct graph_b
+    graph_b->set_num_vertexes(immutable_csr.get_num_vertexes() -
+                              graph_a->get_num_vertexes());
+    graph_b->vdata_ = (VDATA_T*)malloc(
+        sizeof(VDATA_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->globalid_by_index_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+
+    memcpy(graph_b->globalid_by_index_,
+           immutable_csr.globalid_by_index_ + graph_a->get_num_vertexes(),
            sizeof(VID_T) * graph_b->get_num_vertexes());
 
-    graph_b->set_num_out_edges(immutable_csr.get_num_out_edges() - immutable_csr.out_offset_[i]);
-    graph_b->out_offset_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_b->outdegree_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_b->out_edges_ = (VID_T *) malloc(
-        sizeof(VID_T) * ceil(graph_b->get_num_out_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_b->set_num_out_edges(immutable_csr.get_num_out_edges() -
+                               graph_a->get_num_out_edges());
+    graph_b->out_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->outdegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->out_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_out_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    memset(graph_b->out_offset_, 0,
+           sizeof(size_t) * graph_b->get_num_vertexes());
+    memset(graph_b->outdegree_, 0,
+           sizeof(size_t) * graph_b->get_num_vertexes());
+    memset(graph_b->out_edges_, 0, sizeof(VID_T) * graph_b->get_num_edges());
 
     memcpy(graph_b->out_edges_,
-           immutable_csr.out_edges_ + immutable_csr.out_offset_[i],
+           immutable_csr.out_edges_ + graph_a->get_num_out_edges(),
            sizeof(VID_T) * graph_b->get_num_out_edges());
-    memcpy(graph_b->out_offset_, immutable_csr.out_offset_ + i,
+    memcpy(graph_b->out_offset_,
+           immutable_csr.out_offset_ + graph_a->get_num_vertexes(),
            sizeof(size_t) * graph_b->get_num_vertexes());
-    memcpy(graph_b->outdegree_, immutable_csr.outdegree_ + i,
+    memcpy(graph_b->outdegree_,
+           immutable_csr.outdegree_ + graph_a->get_num_vertexes(),
            sizeof(size_t) * graph_b->get_num_vertexes());
 
-    graph_b->set_num_in_edges(immutable_csr.get_num_in_edges() - immutable_csr.in_offset_[i]);
-    graph_b->in_offset_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_b->indegree_ = (size_t *) malloc(
-        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
-    graph_b->in_edges_ = (VID_T *) malloc(
-        sizeof(VID_T) * ceil(graph_b->get_num_in_edges() / ALIGNMENT_FACTOR) * ALIGNMENT_FACTOR);
+    graph_b->set_num_in_edges(immutable_csr.get_num_in_edges() -
+                              graph_a->get_num_in_edges());
+    graph_b->in_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->indegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->in_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_in_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    memset(graph_b->in_offset_, 0,
+           sizeof(size_t) * graph_b->get_num_vertexes());
+    memset(graph_b->indegree_, 0, sizeof(size_t) * graph_b->get_num_vertexes());
+    memset(graph_b->in_edges_, 0, sizeof(VID_T) * graph_b->get_num_edges());
     memcpy(graph_b->in_edges_,
-           immutable_csr.in_edges_ + immutable_csr.in_offset_[i],
+           immutable_csr.in_edges_ + graph_a->get_num_in_edges(),
            sizeof(VID_T) * graph_b->get_num_in_edges());
-    memcpy(graph_b->in_offset_, immutable_csr.in_offset_ + i,
+    memcpy(graph_b->in_offset_,
+           immutable_csr.in_offset_ + graph_a->get_num_vertexes(),
            sizeof(size_t) * graph_b->get_num_vertexes());
-    memcpy(graph_b->indegree_, immutable_csr.indegree_ + i,
+    memcpy(graph_b->indegree_,
+           immutable_csr.indegree_ + graph_a->get_num_vertexes(),
            sizeof(size_t) * graph_b->get_num_vertexes());
-    memcpy(graph_b->vdata_, immutable_csr.vdata_ + i,
+    memcpy(graph_b->vdata_, immutable_csr.vdata_ + graph_a->get_num_vertexes(),
            sizeof(VID_T) * graph_b->get_num_vertexes());
 
-    graph_a->set_in_offset_base(0);
-    graph_a->set_out_offset_base(0);
-    graph_a->set_vid_base(immutable_csr.get_vid_base());
-    graph_a->set_max_vid(i - 1);
-    graph_b->set_in_offset_base(immutable_csr.in_offset_[i]);
-    graph_b->set_out_offset_base(immutable_csr.out_offset_[i]);
-    graph_b->set_vid_base(i);
+    graph_b->set_in_offset_base(
+        immutable_csr.in_offset_[graph_a->get_num_vertexes()]);
+    graph_b->set_out_offset_base(
+        immutable_csr.out_offset_[graph_a->get_num_vertexes()]);
+    graph_b->set_vid_base(
+        immutable_csr.localid2globalid(graph_a->get_num_vertexes()));
     graph_b->set_max_vid(immutable_csr.get_max_vid());
 
     return std::make_pair(graph_a, graph_b);
   }
 
   // Append a new graph im ImmutableCSR format to the trail of linked_list.
-  void Merge(graphs::LinkedListMutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *
+  void Merge(graphs::LinkedListMutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*
                  linkedlist_mutable_csr = nullptr,
-             graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T> *
+             graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*
                  immutable_csr = nullptr) {
     assert(linkedlist_mutable_csr != nullptr && immutable_csr != nullptr);
 
@@ -147,7 +203,7 @@ class SplitMerge {
   }
 };
 
-}// namespace dynamic
-}// namespace utility
-}// namespace minigraph
-#endif// ATOMIC_H_SPLIT_MERGE_H
+}  // namespace dynamic
+}  // namespace utility
+}  // namespace minigraph
+#endif  // ATOMIC_H_SPLIT_MERGE_H

--- a/minigraph/utility/dynamic/split_merge.h
+++ b/minigraph/utility/dynamic/split_merge.h
@@ -1,0 +1,170 @@
+#ifndef ATOMIC_H_SPLIT_MERGE_H
+#define ATOMIC_H_SPLIT_MERGE_H
+
+#include "graphs/immutable_csr.h"
+#include "graphs/linked_list_mutable_csr.h"
+
+namespace minigraph {
+namespace utility {
+namespace dynamic {
+
+template <typename GID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+class SplitMerge {
+ public:
+  SplitMerge() = default;
+  ~SplitMerge() = default;
+
+  // Split the ImmutableCSR graph into two fragments graph_a and graph_b, such
+  // that they are approximately equal in num of edges.
+  std::pair<graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*,
+            graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*>
+  Split(graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>& immutable_csr) {
+    auto graph_a = new graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>;
+    auto graph_b = new graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>;
+
+    size_t tmp_base = immutable_csr.get_num_out_edges() / 2;
+
+    // Binary search for splitted poit.
+    size_t i = immutable_csr.get_num_vertexes() / 2;
+    size_t end = immutable_csr.get_num_vertexes();
+    size_t start = 0;
+
+    while (start <= end) {
+      i = start + (end - start) / 2;
+      if (immutable_csr.out_offset_[i] < tmp_base)
+        start = i + 1;
+      else if (immutable_csr.out_offset_[i] > tmp_base)
+        end = i - 1;
+      else
+        break;
+    }
+    LOG_INFO("i", i);
+
+    // Construct graph_a
+    graph_a->set_num_vertexes(i);
+    graph_a->vdata_ = (VDATA_T*)malloc(
+        sizeof(VDATA_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->globalid_by_index_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+
+    memcpy(graph_a->globalid_by_index_, immutable_csr.globalid_by_index_,
+           sizeof(VID_T) * graph_a->get_num_vertexes());
+
+    graph_a->set_num_out_edges(immutable_csr.out_offset_[i] +
+                               immutable_csr.outdegree_[i]);
+    graph_a->out_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->outdegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->out_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_out_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    memcpy(graph_a->out_edges_, immutable_csr.out_edges_,
+           sizeof(VID_T) * graph_a->get_num_out_edges());
+    memcpy(graph_a->out_offset_, immutable_csr.out_offset_,
+           sizeof(size_t) * graph_a->get_num_vertexes());
+    memcpy(graph_a->outdegree_, immutable_csr.outdegree_,
+           sizeof(size_t) * graph_a->get_num_vertexes());
+
+    graph_a->set_num_in_edges(immutable_csr.in_offset_[i] +
+                              immutable_csr.indegree_[i]);
+    graph_a->in_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->indegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_a->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_a->in_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_a->get_num_in_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    memcpy(graph_a->in_edges_, immutable_csr.in_edges_,
+           sizeof(VID_T) * graph_a->get_num_in_edges());
+    memcpy(graph_a->in_offset_, immutable_csr.in_offset_,
+           sizeof(size_t) * graph_a->get_num_vertexes());
+    memcpy(graph_a->indegree_, immutable_csr.indegree_,
+           sizeof(size_t) * graph_a->get_num_vertexes());
+    memcpy(graph_a->vdata_, immutable_csr.vdata_,
+           sizeof(VID_T) * graph_a->get_num_vertexes());
+
+    // Construct graph_b
+    graph_b->set_num_vertexes(immutable_csr.get_num_vertexes() -
+                              graph_a->get_num_vertexes());
+    graph_b->vdata_ = (VDATA_T*)malloc(
+        sizeof(VDATA_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->globalid_by_index_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+
+    memcpy(graph_b->globalid_by_index_, immutable_csr.globalid_by_index_ + i,
+           sizeof(VID_T) * graph_b->get_num_vertexes());
+
+    graph_b->set_num_out_edges(immutable_csr.get_num_out_edges() -
+                               immutable_csr.out_offset_[i]);
+    graph_b->out_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->outdegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->out_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_out_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+
+    memcpy(graph_b->out_edges_,
+           immutable_csr.out_edges_ + immutable_csr.out_offset_[i],
+           sizeof(VID_T) * graph_b->get_num_out_edges());
+    memcpy(graph_b->out_offset_, immutable_csr.out_offset_ + i,
+           sizeof(size_t) * graph_b->get_num_vertexes());
+    memcpy(graph_b->outdegree_, immutable_csr.outdegree_ + i,
+           sizeof(size_t) * graph_b->get_num_vertexes());
+
+    graph_b->set_num_in_edges(immutable_csr.get_num_in_edges() -
+                              immutable_csr.in_offset_[i]);
+    graph_b->in_offset_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->indegree_ = (size_t*)malloc(
+        sizeof(size_t) * ceil(graph_b->get_num_vertexes() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    graph_b->in_edges_ = (VID_T*)malloc(
+        sizeof(VID_T) * ceil(graph_b->get_num_in_edges() / ALIGNMENT_FACTOR) *
+        ALIGNMENT_FACTOR);
+    memcpy(graph_b->in_edges_,
+           immutable_csr.in_edges_ + immutable_csr.in_offset_[i],
+           sizeof(VID_T) * graph_b->get_num_in_edges());
+    memcpy(graph_b->in_offset_, immutable_csr.in_offset_ + i,
+           sizeof(size_t) * graph_b->get_num_vertexes());
+    memcpy(graph_b->indegree_, immutable_csr.indegree_ + i,
+           sizeof(size_t) * graph_b->get_num_vertexes());
+    memcpy(graph_b->vdata_, immutable_csr.vdata_ + i,
+           sizeof(VID_T) * graph_b->get_num_vertexes());
+
+    graph_b->set_in_offset_base(immutable_csr.in_offset_[i]);
+    graph_b->set_out_offset_base(immutable_csr.out_offset_[i]);
+    graph_a->set_in_offset_base(0);
+    graph_a->set_out_offset_base(0);
+
+    return std::make_pair(graph_a, graph_b);
+  }
+
+  // Append a new graph im ImmutableCSR format to the trail of linked_list.
+  void Merge(graphs::LinkedListMutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*
+                 linkedlist_mutable_csr = nullptr,
+             graphs::ImmutableCSR<GID_T, VID_T, VDATA_T, EDATA_T>*
+                 immutable_csr = nullptr) {
+    assert(linkedlist_mutable_csr != nullptr && immutable_csr != nullptr);
+
+    linkedlist_mutable_csr->GraphAppend(immutable_csr);
+    return;
+  }
+};
+
+}  // namespace dynamic
+}  // namespace utility
+}  // namespace minigraph
+#endif  // ATOMIC_H_SPLIT_MERGE_H


### PR DESCRIPTION
Add LinkedListMutableCSR class to support that merge two CSR graphs in O(1).
It used a LinkedList structure and allows users to find a vertex by globalid.